### PR TITLE
Use a more compatible shebang

### DIFF
--- a/dfu.py
+++ b/dfu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import tealblue
 import sys

--- a/pynus.py
+++ b/pynus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import tealblue
 import termios

--- a/tealblue.py
+++ b/tealblue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import dbus
 import dbus.service


### PR DESCRIPTION
python3 isn't guaranteed to be in /usr/bin/python3 (in NixOS for
example), but env is more likely to be.