### PR TITLE
More compatible shebang

### DIFF
--- a/pynus.py
+++ b/pynus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import tealblue
 import termios


### PR DESCRIPTION
Some systems such as NixOS don't put python in /usr/bin